### PR TITLE
fix: 글로벌 rejection 핸들러로 OOM 방지 + 평문 토큰 로그 제거

### DIFF
--- a/backend/src/api/auth/auth.service.ts
+++ b/backend/src/api/auth/auth.service.ts
@@ -20,15 +20,7 @@ export class AuthService {
 		private worldcoinService: WorldcoinService,
 		private ensureUserService: EnsureUserService,
 		@Inject(CACHE_MANAGER) private cacheManager: Cache,
-	) {
-		setTimeout(() => {
-			this.jwtService
-				.signAsync({ userId: '7eaa002d-3991-491b-bca0-d2133683d582' })
-				.then(token => {
-					console.log('Test Token:', token);
-				});
-		}, 3000);
-	}
+	) {}
 
 	async firebaseLogin({
 		firebaseLoginDTO: { token },
@@ -37,8 +29,6 @@ export class AuthService {
 	}) {
 		const decodedIdToken =
 			await this.firebaseService.decodeBearerToken(token);
-
-		console.log('decodedIdToken', decodedIdToken);
 
 		const partialContext = {
 			firebaseId: decodedIdToken.uid,

--- a/backend/src/instrument.ts
+++ b/backend/src/instrument.ts
@@ -3,8 +3,32 @@ import * as Sentry from '@sentry/nestjs';
 // Ensure to call this before importing any other modules!
 Sentry.init({
 	dsn: 'https://7272387016df3cbe7ea7ad4c351b6fe2@o4508022969335808.ingest.de.sentry.io/4508022972153936',
-	
+
 	// Add Tracing by setting tracesSampleRate
 	// We recommend adjusting this value in production
 	tracesSampleRate: 1.0,
+});
+
+/**
+ * Global safety nets. Without these, a single unhandled promise rejection from
+ * a third-party SDK (ethers RPC timeouts have been the worst offender) can
+ * accumulate listeners/objects in V8 and eventually crash the process with OOM.
+ * We log to stderr and forward to Sentry so we can spot regressions early.
+ */
+process.on('unhandledRejection', (reason: unknown, promise: Promise<unknown>) => {
+	const err = reason instanceof Error ? reason : new Error(String(reason));
+	Sentry.captureException(err, {
+		tags: { source: 'unhandledRejection' },
+		extra: { promise: String(promise) },
+	});
+	// eslint-disable-next-line no-console
+	console.error('[unhandledRejection]', err.message);
+});
+
+process.on('uncaughtException', (err: Error) => {
+	Sentry.captureException(err, { tags: { source: 'uncaughtException' } });
+	// eslint-disable-next-line no-console
+	console.error('[uncaughtException]', err.message, err.stack);
+	// Flush Sentry events, then let PM2 restart the process cleanly.
+	void Sentry.close(2000).finally(() => process.exit(1));
 });


### PR DESCRIPTION
## 요약

백엔드가 ~19일 동안 8,477번 재시작 루프를 돌고 있었음. 원인은 ethers.js RPC 호출에서 발생한 unhandled promise rejection이 V8에 누적되어 결국 OOM으로 프로세스를 죽인 것 + Avalanche RPC 자체의 불안정성. 이 PR은 **두 개의 안정화 PR 중 첫 번째**로, 가장 안전하고 즉효성 있는 변경만 담았습니다.

### 변경 사항
- **`instrument.ts`에 `process.on('unhandledRejection')` / `process.on('uncaughtException')` 핸들러 추가**. 백그라운드에서 발생하는 실패(주로 ethers RPC 타임아웃)가 V8에 쌓여 OOM을 유발하는 대신 Sentry로 보고됨. `uncaughtException` 발생 시 Sentry flush 후 종료해서 PM2가 깨끗하게 재시작.
- **민감 데이터를 흘리던 `console.log` 두 개 제거**:
  - `auth.service.ts` 생성자에서 부팅 후 3초 뒤 어드민 유저의 JWT를 stdout으로 출력 — 로그 접근 권한 있는 사람이라면 누구나 admin 사칭 가능했음
  - `firebaseLogin`이 매 로그인마다 디코딩된 Firebase 토큰 전체(uid, email 등 PII) 출력

### 이번 PR에 **포함되지 않은 것** (#11에서 진행)
- DRPC + 1RPC 사이를 round-robin하는 ethers `FallbackProvider`
- `AVALANCHE_RPC_URLS` 환경변수 (다중 URL 지원)
- `mintPfpToken`의 타임아웃/리트라이 강화

작업을 둘로 쪼개서 이 PR이 작고 롤백하기 쉽게 만들었음.

### 배경
- 진단 결과 root cause: PM2 로그에서 `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`. `api.avax.network`에서 오는 ethers `_send` rejection (500, ETIMEDOUT, replacement-underpriced)으로 추적됨.
- 오늘 EC2에서 코드 변경 없이 직접 적용한 완화 조치들:
  - `AVALANCHE_RPC_URL`을 `api.avax.network` → `avalanche.drpc.org`로 교체 (이미 적용 중)
  - PM2 로그 truncate (23GB 회수) + `pm2-logrotate` 설정 (max 100M, 30일 보관, 일일 회전, 압축)
  - PM2 `--max-memory-restart 1500M` 적용 + `pm2 save`로 영구화

## 테스트 플랜

- [x] CI 빌드 통과
- [x] EC2 dev 배포: `git pull && pnpm install -r --frozen-lockfile && pnpm --filter backend build && pm2 reload backend --update-env`
- [x] 헬스체크: `curl -s http://localhost:8000/`이 1초 내 200
- [x] 부팅 후 `pm2 logs backend`에 `Test Token:` 라인 안 나옴
- [x] Firebase 로그인 후 `decodedIdToken` 라인 안 나옴
- [ ] `pm2 status`로 1시간 모니터링: restart 카운터가 증가하지 않아야 함
- [ ] 비프로덕션 환경에서 의도적인 unhandled rejection 발생시켜 Sentry로 가는지 확인 (프로세스가 안 죽어야 함)