### PR TITLE
feat(avalanche): minting 안정화를 위한 FallbackProvider + RPC 타임아웃

### DIFF
--- a/backend/src/modules/avalanche/avalanche-nft.service.ts
+++ b/backend/src/modules/avalanche/avalanche-nft.service.ts
@@ -1,24 +1,92 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { ethers } from 'ethers';
+import {
+    ethers,
+    FallbackProvider,
+    FetchRequest,
+    JsonRpcProvider,
+    Network,
+} from 'ethers';
 import { EnvironmentVariables } from '@/utils/env';
 import { SBT_ABI, SBT_BYTECODE, PFP_ABI } from './abi';
 
+const AVAX_CHAIN_ID = 43114;
+// Per-call HTTP timeout. The public Avalanche RPCs occasionally hang; without
+// this, ethers waits ~2 minutes before failing over.
+const RPC_TIMEOUT_MS = 8_000;
+// How long FallbackProvider waits before considering a provider stalled and
+// trying the next one.
+const RPC_STALL_MS = 1_500;
+
 @Injectable()
 export class AvalancheNftService {
-    private provider: ethers.JsonRpcProvider;
+    private readonly logger = new Logger(AvalancheNftService.name);
+    private provider: ethers.AbstractProvider;
     private wallet: ethers.Wallet;
 
     constructor(
         private configService: ConfigService<EnvironmentVariables, true>,
     ) {
-        this.provider = new ethers.JsonRpcProvider(
-            this.configService.get('AVALANCHE_RPC_URL')
-        );
+        const urls = this.resolveRpcUrls();
+        this.provider = this.buildProvider(urls);
         this.wallet = new ethers.Wallet(
             this.configService.get('AVALANCHE_PRIVATE_KEY'),
-            this.provider
+            this.provider,
         );
+    }
+
+    private resolveRpcUrls(): string[] {
+        const multi = this.configService.get('AVALANCHE_RPC_URLS' as never) as
+            | string[]
+            | undefined;
+        if (Array.isArray(multi) && multi.length > 0) {
+            return multi;
+        }
+        return [this.configService.get('AVALANCHE_RPC_URL')];
+    }
+
+    private buildProvider(urls: string[]): ethers.AbstractProvider {
+        // Pinning the network prevents ethers from issuing an extra eth_chainId
+        // probe on every request, which is both slower and a common source of
+        // "failed to detect network" errors when an RPC is misbehaving.
+        const network = Network.from(AVAX_CHAIN_ID);
+        const make = (url: string): JsonRpcProvider => {
+            const req = new FetchRequest(url);
+            req.timeout = RPC_TIMEOUT_MS;
+            return new JsonRpcProvider(req, network, {
+                staticNetwork: network,
+            });
+        };
+
+        if (urls.length === 1) {
+            this.logger.log(
+                `Avalanche RPC: single endpoint ${this.redact(urls[0])}`,
+            );
+            return make(urls[0]);
+        }
+
+        this.logger.log(
+            `Avalanche RPC: FallbackProvider with ${urls.length} endpoints [${urls.map((u) => this.redact(u)).join(', ')}]`,
+        );
+        return new FallbackProvider(
+            urls.map((url, index) => ({
+                provider: make(url),
+                priority: index + 1, // lower index → higher priority
+                stallTimeout: RPC_STALL_MS,
+                weight: 1,
+            })),
+            network,
+            { quorum: 1 },
+        );
+    }
+
+    private redact(url: string): string {
+        try {
+            const u = new URL(url);
+            return `${u.protocol}//${u.host}`;
+        } catch {
+            return url;
+        }
     }
 
     async deployContract({

--- a/backend/src/utils/env.ts
+++ b/backend/src/utils/env.ts
@@ -114,6 +114,23 @@ export class EnvironmentVariables {
 	@IsString()
 	AVALANCHE_RPC_URL!: string;
 
+	/**
+	 * Optional comma-separated list of Avalanche C-Chain RPC URLs.
+	 * When set with 2+ entries, the service uses ethers FallbackProvider so a
+	 * single RPC outage no longer takes down minting. When unset (or single
+	 * entry), behavior is identical to the legacy single-URL setup driven by
+	 * AVALANCHE_RPC_URL.
+	 */
+	@IsOptional()
+	@Transform(({ value }) =>
+		typeof value === 'string' && value.length > 0
+			? splitStringIntoNonBlankArray(value)
+			: undefined,
+	)
+	@IsArray()
+	@IsString({ each: true })
+	AVALANCHE_RPC_URLS?: string[];
+
 	@IsNotEmpty()
 	@IsString()
 	AVALANCHE_PRIVATE_KEY!: string;


### PR DESCRIPTION
## 요약

#10의 후속 PR. 첫 번째 PR이 unhandled rejection을 잡아서 더 이상 OOM으로 죽지 않게 했다면, 이 PR은 **그 rejection이 발생한 근본 원인** — 불안정한 퍼블릭 Avalanche RPC — 를 해결합니다.

### 변경 사항
- 새 환경변수 `AVALANCHE_RPC_URLS` (콤마 구분, optional) 추가. 2개 이상 지정하면 `AvalancheNftService`가 ethers **`FallbackProvider`** 로 감싸서, 한 RPC가 죽어도 PFP 민팅이 계속 동작합니다.
- 각 `JsonRpcProvider`를 `FetchRequest`로 감싸 **HTTP 타임아웃 8초** 적용. 멈춘 RPC가 약 2분 동안 대롱대롱 매달려서 #10에서 잡힌 rejection을 만들던 문제를 차단.
- `Network.from(43114)` + `staticNetwork` 옵션으로 chain id를 고정 → 매 호출마다 `eth_chainId` 프로브를 보내던 동작 제거. 이 프로브 자체가 "failed to detect network" 에러의 원흉이었음.
- `FallbackProvider` 옵션: `priority` (DRPC가 1순위, 1RPC가 2순위), `stallTimeout: 1500ms`, `quorum: 1` — 즉 **하나라도 살아있으면 OK**.

### 후방 호환성
- `AVALANCHE_RPC_URLS` 미설정 시 기존 단일 `AVALANCHE_RPC_URL` 그대로 사용. 동작은 오늘과 동일하되 8초 타임아웃과 chain id 고정만 적용 (둘 다 명백한 개선).
- `EnvironmentVariables.AVALANCHE_RPC_URLS`는 `@IsOptional()`이라, 기존 배포본은 `.env` 안 건드려도 그냥 돌아감.

### 운영 적용 (머지 후 EC2 작업)

`/home/ec2-user/HideMePleaseBE/.env`에 한 줄 추가:

```diff
 AVALANCHE_RPC_URL=https://avalanche.drpc.org
+AVALANCHE_RPC_URLS=https://avalanche.drpc.org,https://1rpc.io/avax/c
```

그 다음 평소처럼 배포:
```bash
cd /home/ec2-user/HideMePleaseBE
git pull origin master
pnpm install -r --frozen-lockfile
pnpm --filter backend build
pm2 reload backend --update-env
```

기동 로그에서 다음 줄이 보여야 함:
```
[AvalancheNftService] Avalanche RPC: FallbackProvider with 2 endpoints [https://avalanche.drpc.org, https://1rpc.io]
```

## 테스트 플랜

- [ ] CI 빌드 통과 (`pnpm --filter backend build`)
- [ ] `AVALANCHE_RPC_URLS` 미설정 상태로 배포 → 로그에 "single endpoint" 표시 확인 + 민팅 정상 동작 (후방 호환)
- [ ] `AVALANCHE_RPC_URLS=drpc,1rpc` 설정 후 배포 → 로그에 "FallbackProvider with 2 endpoints" 확인
- [ ] FallbackProvider 상태에서 `mintPfpToken` dry-run (`estimateGas`만) → 1초 이내 성공
- [ ] DRPC를 30초간 방화벽으로 차단 → 1RPC로 페일오버되어 민팅 계속 성공해야 함
- [ ] 24시간 동안 Sentry에서 ethers 관련 rejection 모니터링 → 현재 베이스라인에서 거의 0으로 떨어져야 함

## 관련 PR
- #10 — 글로벌 unhandled rejection 핸들러 + 평문 토큰 로그 제거 (머지됨)