### PR TITLE
feat(avalanche): 회사 민팅 지갑 잔액 5분 주기 모니터링 + Sentry 알림

### DIFF
--- a/backend/src/api/nft/nft.module.ts
+++ b/backend/src/api/nft/nft.module.ts
@@ -17,6 +17,7 @@ import { SendbirdModule } from '@/modules/sendbird/sendbird.module';
 import { SystemConfigModule } from '@/modules/system-config/system-config.module';
 import { UnifiedNftModule } from '@/modules/unified-nft/unified-nft.module';
 import { AvalancheNftService } from '@/modules/avalanche/avalanche-nft.service';
+import { AvalancheWalletMonitorService } from '@/modules/avalanche/avalanche-wallet-monitor.service';
 
 @Module({
 	imports: [
@@ -39,6 +40,7 @@ import { AvalancheNftService } from '@/modules/avalanche/avalanche-nft.service';
 		NftCommunityService,
 		NftLevelService,
 		AvalancheNftService,
+		AvalancheWalletMonitorService,
 	],
 	exports: [
 		WelcomeNftService,

--- a/backend/src/modules/avalanche/avalanche-nft.service.ts
+++ b/backend/src/modules/avalanche/avalanche-nft.service.ts
@@ -89,6 +89,25 @@ export class AvalancheNftService {
         }
     }
 
+    /**
+     * Returns the current balance of the wallet that signs minting transactions.
+     * Used by AvalancheWalletMonitorService for periodic low-balance alerts so we
+     * never wake up to "minting silently broken because the company wallet ran
+     * out of AVAX again".
+     */
+    async getMintingWalletBalance(): Promise<{
+        address: string;
+        balanceWei: bigint;
+        balanceAvax: string;
+    }> {
+        const balanceWei = await this.provider.getBalance(this.wallet.address);
+        return {
+            address: this.wallet.address,
+            balanceWei,
+            balanceAvax: ethers.formatEther(balanceWei),
+        };
+    }
+
     async deployContract({
         name,
         symbol,

--- a/backend/src/modules/avalanche/avalanche-wallet-monitor.service.ts
+++ b/backend/src/modules/avalanche/avalanche-wallet-monitor.service.ts
@@ -1,0 +1,93 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
+import { ethers } from 'ethers';
+
+import { AvalancheNftService } from './avalanche-nft.service';
+
+/**
+ * 0.1 AVAX. Below this we send a Sentry warning so an operator can top up
+ * before any mints fail. mintPfpToken's own pre-flight check requires 0.01.
+ */
+const WARNING_THRESHOLD_WEI = ethers.parseEther('0.1');
+
+/**
+ * 0.05 AVAX. Below this we send a Sentry error: minting will start failing
+ * very soon and on-call should treat this as urgent.
+ */
+const CRITICAL_THRESHOLD_WEI = ethers.parseEther('0.05');
+
+/**
+ * Polls the company minting wallet's AVAX balance and reports low-balance
+ * conditions to Sentry. We did *not* hook this directly into SNS because:
+ *
+ *  - Sentry already has email routing to the on-call inbox.
+ *  - Going through Sentry gives us deduplication, fingerprinting, and history
+ *    for free, which a raw SNS publish wouldn't.
+ *
+ * If/when we want hard escalation to SNS we can add it here later — the
+ * IAM role on this instance already has sns:Publish.
+ */
+@Injectable()
+export class AvalancheWalletMonitorService implements OnModuleInit {
+	private readonly logger = new Logger(AvalancheWalletMonitorService.name);
+
+	constructor(private readonly avalancheNftService: AvalancheNftService) {}
+
+	async onModuleInit() {
+		// Run once at startup so we don't have to wait up to 5 minutes after a
+		// deploy to learn the wallet is empty.
+		void this.checkBalance();
+	}
+
+	@Cron(CronExpression.EVERY_5_MINUTES, {
+		name: 'avalancheWalletBalanceCheck',
+	})
+	async checkBalance(): Promise<void> {
+		try {
+			const { address, balanceWei, balanceAvax } =
+				await this.avalancheNftService.getMintingWalletBalance();
+
+			if (balanceWei < CRITICAL_THRESHOLD_WEI) {
+				const message = `Minting wallet balance critically low: ${balanceAvax} AVAX (< 0.05). Minting will start failing soon.`;
+				this.logger.error(`${message} address=${address}`);
+				Sentry.captureMessage(message, {
+					level: 'error',
+					tags: {
+						component: 'wallet-monitor',
+						severity: 'critical',
+					},
+					extra: { address, balanceAvax, threshold: '0.05' },
+				});
+				return;
+			}
+
+			if (balanceWei < WARNING_THRESHOLD_WEI) {
+				const message = `Minting wallet balance low: ${balanceAvax} AVAX (< 0.1). Top up soon.`;
+				this.logger.warn(`${message} address=${address}`);
+				Sentry.captureMessage(message, {
+					level: 'warning',
+					tags: {
+						component: 'wallet-monitor',
+						severity: 'warning',
+					},
+					extra: { address, balanceAvax, threshold: '0.1' },
+				});
+				return;
+			}
+
+			this.logger.log(
+				`Minting wallet balance OK: ${balanceAvax} AVAX (address=${address})`,
+			);
+		} catch (e) {
+			const err = e instanceof Error ? e : new Error(String(e));
+			this.logger.error(`Wallet balance check failed: ${err.message}`);
+			Sentry.captureException(err, {
+				tags: {
+					component: 'wallet-monitor',
+					kind: 'check-failed',
+				},
+			});
+		}
+	}
+}


### PR DESCRIPTION
## 요약

회사 민팅 지갑(`0x1d18A3D...`)의 AVAX 잔액이 떨어지면 `mintPfpToken`이 사전 점검(`< 0.01 AVAX` 거절)에서 항상 실패하지만, **현재 구조로는 사람이 직접 잔액을 확인하지 않으면 부족 상태를 알 수 없습니다.** 이번 19일 장애의 원인은 잔액 부족이 아니라 RPC 불안정성이었지만, 잔액 부족 시나리오는 별개로 분명히 존재하는 운영상 사각지대이므로 사전적으로 차단합니다.

> ⚠️ 명확히: 이번 장애의 1차 원인은 **공개 RPC(api.avax.network)의 불안정성으로 인한 unhandled rejection 누적 → OOM** 이었고 (PR #10/#11에서 처리됨), 잔액 부족이 원인이라는 증거는 없습니다. 이 PR은 별개의 잠재적 사각지대를 메우는 작업입니다.

### 변경 사항
- 새 `AvalancheWalletMonitorService` (`backend/src/modules/avalanche/avalanche-wallet-monitor.service.ts`)
  - `@Cron(EVERY_5_MINUTES)` + `OnModuleInit` 에서 1회 — 부팅 직후 즉시 첫 체크 후 이후 5분마다 반복
  - 잔액 < 0.1 AVAX → Sentry **warning** (`Top up soon`)
  - 잔액 < 0.05 AVAX → Sentry **error** (`Minting will start failing soon`)
  - 잔액 조회 실패 → Sentry **exception** (FallbackProvider 덕에 거의 발생 안 해야 정상)
- `AvalancheNftService.getMintingWalletBalance()` 헬퍼만 추가 — `provider`/`wallet`은 여전히 private 유지 (캡슐화)
- `nft.module.ts`의 providers에 `AvalancheWalletMonitorService` 등록

### 왜 Sentry 단독인가 (SNS 직접 발송이 아니라)
- on-call 이메일 라우팅이 이미 Sentry에 잡혀있음
- dedup/fingerprint/history/이슈 자동 그룹핑 등 운영 편의성을 그대로 활용 가능
- 추후 hard-escalation이 필요하면 같은 위치에 `sns:Publish` 한 줄만 추가하면 됨 (해당 IAM 권한 EC2 instance role에 이미 부착됨)

### 임계값 근거
- `mintPfpToken` 자체가 0.01 AVAX 미만이면 사전 거절 (이미 코드에 있음)
- 0.1 = ~30~100회 민팅 분량의 여유 — 운영자가 24~48시간 내 충전할 시간 확보
- 0.05 = ~10~30회 분량 — 즉시 충전 시급
- 현재 잔액(2026-05-20 기준): 약 0.77 AVAX — 한참 OK 상태

## 운영 적용

머지 후 평소처럼 배포만 하면 됩니다. 환경변수 추가 없음.

```bash
cd /home/ec2-user/HideMePleaseBE
git pull origin master
pnpm install -r --frozen-lockfile
pnpm --filter backend build
pm2 reload backend --update-env
```

부팅 직후 PM2 로그에 다음 라인 보임:
```
[AvalancheWalletMonitorService] Minting wallet balance OK: 0.7690... AVAX (address=0x1d18A3D...)
```

이후 5분마다 동일 라인 반복 (잔액 OK일 때).

## 테스트 플랜

- [ ] CI 빌드 통과
- [ ] 배포 후 부팅 로그에 `Minting wallet balance OK` 라인 확인 (현재 잔액 ~0.77 AVAX)
- [ ] 5분 후 동일 라인 한 번 더 찍히는지 (cron 정상 작동)
- [ ] 임시로 `WARNING_THRESHOLD_WEI`를 1 AVAX로 올린 다음 배포 → Sentry에 warning 이슈 도착 확인 → 원복
- [ ] 24시간 동안 cron 누락 없이 매 5분 호출됐는지 (PM2 로그에서 호출 횟수 확인)

## 관련 PR / 이번 incident에서 진행한 작업
- #10 — 글로벌 unhandled rejection 핸들러 + 평문 토큰 로그 제거 (머지됨, 실제 OOM 원인 차단)
- #11 — RPC FallbackProvider + per-call timeout (머지됨, 실제 RPC 불안정성 해결)
- 이 PR — 잔액 부족이라는 **별개의 잠재적 사각지대** 사전 모니터링